### PR TITLE
Rake upgrade + Heroku removed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       nokogiri (~> 1.5.0)
       pg (~> 0.18.2)
       rack-flash3
-      rake (~> 0.9.2.2)
+      rake
       sass (~> 3.2.19)
       sequel (~> 4.24.0)
       sequel_pg (~> 1.6.13)
@@ -22,7 +22,6 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.2)
     capybara (2.0.3)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -33,7 +32,7 @@ GEM
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
-    chunky_png (1.3.4)
+    chunky_png (1.3.5)
     coderay (1.0.9)
     compass (0.12.7)
       chunky_png (~> 1.2)
@@ -42,34 +41,22 @@ GEM
     daemons (1.1.9)
     database_cleaner (0.9.1)
     eventmachine (1.0.3)
-    excon (0.16.4)
     ffi (1.6.0)
     fssm (0.2.10)
     grid-coordinates (1.1.9)
       compass (>= 0.11.5)
-    haml (4.0.6)
+    haml (4.0.7)
       tilt
-    heroku (2.32.4)
-      heroku-api (~> 0.3.5)
-      launchy (>= 0.3.2)
-      netrc (~> 0.7.7)
-      rest-client (~> 1.6.1)
-      rubyzip
-    heroku-api (0.3.5)
-      excon (~> 0.16.1)
     httparty (0.8.3)
       multi_json (~> 1.0)
       multi_xml
     i18n (0.7.0)
-    launchy (2.1.2)
-      addressable (~> 2.3)
     method_source (0.8.1)
     mime-types (1.19)
     multi_json (1.3.6)
     multi_xml (0.5.5)
-    netrc (0.7.7)
     nokogiri (1.5.5)
-    pg (0.18.2)
+    pg (0.18.3)
     pry (0.9.12)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -83,9 +70,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
-    rake (0.9.2.2)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rake (10.4.2)
     rubyzip (0.9.9)
     sass (3.2.19)
     selenium-webdriver (2.31.0)
@@ -110,7 +95,7 @@ GEM
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
-    tilt (1.4.1)
+    tilt (2.0.1)
     websocket (1.0.7)
     will_paginate (3.0.7)
     xpath (1.0.0)
@@ -123,7 +108,6 @@ DEPENDENCIES
   capybara
   database_cleaner
   faqtly!
-  heroku
   pry
   pry-nav
   rack-test

--- a/faqtly.gemspec
+++ b/faqtly.gemspec
@@ -9,9 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{FAQtly}
   s.description = %q{FAQtly: FAQ Open Source}
 
-  s.rubyforge_project = "faqtly"
-
-  s.add_dependency 'rake', '~> 0.9.2.2'
+  s.add_dependency 'rake'
   s.add_dependency 'i18n'
   s.add_dependency 'httparty', '~> 0.8.1'
   s.add_dependency 'nokogiri', '~> 1.5.0'
@@ -35,7 +33,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'heroku'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
Hey @etagwerker,

This PR simply moves the latest `develop` to `master`, includes the Rake upgrade (https://github.com/ombulabs/faqtly/pull/20).

Please check it out, thanks! 
