### PR TITLE
Revert "Bump version of will_paginate."

### DIFF
--- a/faqtly.gemspec
+++ b/faqtly.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sinatra-support'
   s.add_dependency 'haml', '~> 4.0.5'
   s.add_dependency 'sequel', '~> 4.24.0'
-  s.add_dependency 'will_paginate', '~> 3.1.3'
+  s.add_dependency 'will_paginate', '~> 3.0.5'
 
   # Sass & Compass
   s.add_dependency 'sass', '~> 3.2.19'


### PR DESCRIPTION
Hey @etagwerker,

This PR reverts ombulabs/faqtly#23

OmbuShop depends on `will_paginate ~> 3.0.5`, and we can't bump the `will_paginate` version in OmbuShop as templates will throw this error:

`Liquid error: unsupported parameters: :include`

`bundle` fails to resolve the `will_paginate` versions if we use `~> 3.1.3` for `faqtly`.

Please check it out, thanks! 
